### PR TITLE
Z1nun

### DIFF
--- a/every-board/src/app/board/detail/page.tsx
+++ b/every-board/src/app/board/detail/page.tsx
@@ -8,7 +8,6 @@ import PostCard from "@/components/PostCard";
 const Dashboard = () => {
   return (
     <Main>
-      <Header title="자유게시판" />
       <PostCard detail={true} />
     </Main>
   );

--- a/every-board/src/app/board/layout.tsx
+++ b/every-board/src/app/board/layout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 // Layout 컴포넌트
-import Footer from "../../components/Footer";
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
 import styled from "styled-components";
 
 interface LayoutProps {
@@ -19,6 +20,7 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Wrapper>
+        <Header />
         {children}
         <Footer />
       </Wrapper>

--- a/every-board/src/app/board/mypost/page.tsx
+++ b/every-board/src/app/board/mypost/page.tsx
@@ -1,3 +1,26 @@
-export default function page() {
-  return <div>mypost</div>
-}
+"use client";
+
+import PostCard from "@/components/PostCard";
+import Header from "@/components/Header";
+import styled from "styled-components";
+
+const Mypost = () => {
+  return (
+    <Main>
+      <Header title="MyPost" />
+      <PostCard />
+      <PostCard />
+      <PostCard />
+      <PostCard />
+    </Main>
+  );
+};
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-bottom: 20px;
+`;
+
+export default Mypost;

--- a/every-board/src/app/board/mypost/page.tsx
+++ b/every-board/src/app/board/mypost/page.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 const Mypost = () => {
   return (
     <Main>
-      <Header title="MyPost" />
       <PostCard />
       <PostCard />
       <PostCard />

--- a/every-board/src/app/board/myprofile/page.tsx
+++ b/every-board/src/app/board/myprofile/page.tsx
@@ -103,7 +103,6 @@ const Alarm = styled.p``;
 export default function page() {
   return (
     <>
-      <Header title="Profile" />
       <Wrapper>
         <Section1>
           <Left>

--- a/every-board/src/app/board/myscrap/page.tsx
+++ b/every-board/src/app/board/myscrap/page.tsx
@@ -1,11 +1,26 @@
 "use client";
-import Header from "@/components/Header";
 
-export default function page() {
+import PostCard from "@/components/PostCard";
+import Header from "@/components/Header";
+import styled from "styled-components";
+
+const Mypost = () => {
   return (
-    <>
-      <Header title="Scrap" />
-      <div>스크랩페이지</div>
-    </>
+    <Main>
+      <Header title="MyScrap" />
+      <PostCard />
+      <PostCard />
+      <PostCard />
+      <PostCard />
+    </Main>
   );
-}
+};
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-bottom: 20px;
+`;
+
+export default Mypost;

--- a/every-board/src/app/board/myscrap/page.tsx
+++ b/every-board/src/app/board/myscrap/page.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 const Mypost = () => {
   return (
     <Main>
-      <Header title="MyScrap" />
       <PostCard />
       <PostCard />
       <PostCard />

--- a/every-board/src/app/board/page.tsx
+++ b/every-board/src/app/board/page.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 const Dashboard = () => {
   return (
     <Main>
-      <Header title="자유게시판" />
       <PostCard />
       <PostCard />
       <PostCard />

--- a/every-board/src/app/board/post/page.tsx
+++ b/every-board/src/app/board/post/page.tsx
@@ -197,7 +197,6 @@ export default function page() {
 
   return (
     <>
-      <Header title="PostWriting" />
       <Wrapper>
         <Box1>
           <Avatar></Avatar>

--- a/every-board/src/app/gallery/page.tsx
+++ b/every-board/src/app/gallery/page.tsx
@@ -1,0 +1,5 @@
+const Gallery = () => {
+  return <div>갤러리</div>;
+};
+
+export default Gallery;

--- a/every-board/src/components/Avatar.tsx
+++ b/every-board/src/components/Avatar.tsx
@@ -9,16 +9,21 @@ type Props = {
 //size를 따로 명시하지 않으면 기본적으로 large사이즈
 export default function Avatar({ image }: Props) {
   return (
-    <AvatarWrap>
-      <Image
-        src={"/frame.png"}
-        alt="프로필 사진"
-        width={40}
-        height={40}
-        style={{ borderRadius: "50px" }}
-      />
-      <span>일이삼사오육칠팔구십</span>
-    </AvatarWrap>
+    <Link
+      href="/board/myprofile"
+      style={{ textDecoration: "none", color: "#000000", cursor: "pointer" }}
+    >
+      <AvatarWrap>
+        <Image
+          src={"/frame.png"}
+          alt="프로필 사진"
+          width={40}
+          height={40}
+          style={{ borderRadius: "50px" }}
+        />
+        <NickName>일이삼사오육칠팔</NickName>
+      </AvatarWrap>
+    </Link>
   );
 }
 
@@ -27,17 +32,19 @@ const AvatarWrap = styled.span`
   align-items: center;
   justify-content: center;
   width: fit-content;
-  max-width: 150px;
+  max-width: 170px;
   padding: 8px;
   height: 50px;
   border-radius: 25px;
   background-color: white;
   gap: 6px;
+`;
 
-  white-space: normal;
-  //PostCard 콘텐츠 5줄만 보이기
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
+//닉네임 7글자 이상은 ...처리
+const NickName = styled.span`
+  padding: 0 5px;
+  max-width: 108px;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/every-board/src/components/Avatar.tsx
+++ b/every-board/src/components/Avatar.tsx
@@ -21,7 +21,7 @@ export default function Avatar({ image }: Props) {
           height={40}
           style={{ borderRadius: "50px" }}
         />
-        <NickName>일이삼사오육칠팔</NickName>
+        <NickName>지쳐있는멜모</NickName>
       </AvatarWrap>
     </Link>
   );
@@ -32,19 +32,28 @@ const AvatarWrap = styled.span`
   align-items: center;
   justify-content: center;
   width: fit-content;
-  max-width: 170px;
-  padding: 8px;
-  height: 50px;
-  border-radius: 25px;
+  height: fit-content;
+  max-width: 240px;
+  padding: 2px;
+  border-radius: 50px;
   background-color: white;
   gap: 6px;
+  box-shadow: 1px 2px 20px rgba(18, 61, 101, 0.05),
+    inset -18.4px -13.8px 184px rgba(255, 255, 255, 0.18);
+  @media (min-width: 1080px) {
+    padding: 6px;
+  }
 `;
 
-//닉네임 7글자 이상은 ...처리
+//닉네임 10글자 이상은 ...처리
 const NickName = styled.span`
-  padding: 0 5px;
-  max-width: 108px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: none;
+  @media (min-width: 1080px) {
+    display: inline;
+    padding: 0 5px;
+    max-width: 173px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 `;

--- a/every-board/src/components/ButtonLayout.tsx
+++ b/every-board/src/components/ButtonLayout.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
+import Link from "next/link";
 
-type Props = {
+interface Props {
   text?: React.ReactNode;
   width?: string;
   height?: string;
@@ -10,10 +11,11 @@ type Props = {
   radius?: string;
   padding?: string;
   border?: string;
+  router?: string;
   onClick?: () => void;
-};
+}
 
-type StyleProps = {
+interface StyleProps {
   width?: string;
   height?: string;
   color?: string;
@@ -22,10 +24,17 @@ type StyleProps = {
   radius?: string;
   padding?: string;
   border?: string;
-};
+}
 
 const ButtonLayout = (props: Props) => {
-  return <Button {...props}>{props.text}</Button>;
+  return (
+    <Link
+      href={typeof props.router !== "undefined" ? props.router : ""}
+      style={{ textDecoration: "none" }}
+    >
+      <Button {...props}>{props.text}</Button>
+    </Link>
+  );
 };
 
 const Button = styled.button<StyleProps>`

--- a/every-board/src/components/Category.tsx
+++ b/every-board/src/components/Category.tsx
@@ -2,10 +2,8 @@
 
 import styled from "styled-components";
 import ButtonLayout from "./ButtonLayout";
-import { useRouter } from "next/navigation";
 
 const Category = () => {
-  const router = useRouter();
   const categories = [
     "자유게시판",
     "IT",
@@ -23,18 +21,18 @@ const Category = () => {
     "맛집",
     "제주도",
     "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
-    "일본",
+    "해외여행",
+    "사건사고",
+    "프론트엔드",
+    "백엔드",
+    "자바",
+    "타입스크립트",
+    "리액트",
+    "테마파크",
+    "조명",
+    "의자",
+    "컴퓨터",
+    "노트북",
   ];
 
   return (
@@ -42,12 +40,7 @@ const Category = () => {
       <ul>
         {categories.map((el, index) => {
           return (
-            <li
-              key={index}
-              onClick={() => {
-                router.push("/board");
-              }}
-            >
+            <li key={index}>
               <ButtonLayout
                 text={`${el}`}
                 width="75px"
@@ -57,6 +50,7 @@ const Category = () => {
                 background="#EFE9FF50"
                 fontSize="0.75rem"
                 border="none"
+                router={`/board?category=${el}`}
               />
             </li>
           );

--- a/every-board/src/components/Header.tsx
+++ b/every-board/src/components/Header.tsx
@@ -1,14 +1,25 @@
 import styled from "styled-components";
 import Image from "next/image";
 import Avatar from "./Avatar";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
-interface HeaderProps {
-  title?: string;
-}
-
-const Header = ({ title }: HeaderProps) => {
+const Header = () => {
   const router = useRouter();
+  const [currentTitle, setCurrentTitle] = useState<string | null>(null);
+
+  useEffect(() => {
+    const urlParams = new URL(location.href).searchParams;
+    const category: string | null = urlParams.get("category");
+    const endPoint = window.location.href
+      .split("/")
+      .splice(-1)
+      .join("")
+      .toUpperCase();
+
+    category !== null ? setCurrentTitle(category) : setCurrentTitle(endPoint);
+  }, []);
+
   return (
     <Top>
       <Left>
@@ -17,12 +28,12 @@ const Header = ({ title }: HeaderProps) => {
           width={45}
           height={45}
           alt="logo"
+          style={{ cursor: "pointer" }}
           onClick={() => {
             router.push("/");
           }}
-          style={{ cursor: "pointer" }}
         />
-        <Title>{title}</Title>
+        <Title>{currentTitle}</Title>
       </Left>
       <Avatar />
     </Top>
@@ -35,7 +46,7 @@ const Top = styled.div`
   align-items: center;
   justify-content: space-between;
   margin: 0 auto;
-  padding-top: 2.5rem;
+  padding: 2.5rem 0 1.875rem;
   width: 350px;
 
   @media (min-width: 768px) {

--- a/every-board/src/components/PostCard/Reply.tsx
+++ b/every-board/src/components/PostCard/Reply.tsx
@@ -49,10 +49,12 @@ const CommentContainer = styled.div`
 `;
 
 const CommentWrap = styled.div`
+  margin-left: -50px;
   display: flex;
   gap: 10px;
 
   @media (min-width: 768px) {
+    margin-left: 0;
     width: 550px;
   }
   @media (min-width: 1080px) {

--- a/every-board/src/components/PostCard/UserAction.tsx
+++ b/every-board/src/components/PostCard/UserAction.tsx
@@ -72,24 +72,22 @@ const UserActionContainer = styled.div`
   font-weight: 500;
   color: #838a91;
   line-height: 14px;
+  .comment {
+    margin-left: 50px;
+  }
 
   @media (min-width: 768px) {
     width: 600px;
     justify-content: flex-start;
+    .reply {
+      margin-left: 50px;
+    }
   }
   @media (min-width: 1080px) {
     width: 900px;
   }
   @media (min-width: 1440px) {
     width: 1100px;
-  }
-
-  //댓글 좋아요, 댓글 버튼 위치 소폭 변경
-  .comment,
-  .reply {
-    @media (min-width: 768px) {
-      margin-left: 50px;
-    }
   }
 `;
 

--- a/every-board/src/components/PostCard/UserAction.tsx
+++ b/every-board/src/components/PostCard/UserAction.tsx
@@ -5,13 +5,13 @@ import { AiFillHeart } from "react-icons/ai";
 import { BiCommentDetail } from "react-icons/bi";
 import styled from "styled-components";
 
-const UserAction = ({
-  comment,
-  reply,
-}: {
+interface Props {
   comment?: boolean;
   reply?: boolean;
-}) => {
+}
+
+const UserAction = (props: Props) => {
+  const { comment, reply } = props;
   const [isLikeClick, setLike] = useState<boolean>(false);
   const [isCommentClick, setComment] = useState<boolean>(false);
   return (
@@ -53,7 +53,9 @@ const UserAction = ({
           </span>
         )}
       </UserActionWrap>
-      {isCommentClick ? comment ? <Reply /> : <Comment /> : null}
+      {/* 댓글을 누르고 댓글의 댓글을 눌렀을 경우(대댓글) Reply 컴포넌트 
+          Reply 컴포넌트는 한칸 들여쓰기가 더 들어가있습니다! 
+          나중에 한개로 통일 할 수 있는 방법 생각하기*/}
       {isCommentClick ? comment ? <Reply /> : <Comment /> : null}
     </UserActionContainer>
   );

--- a/every-board/src/components/home/Header.tsx
+++ b/every-board/src/components/home/Header.tsx
@@ -24,7 +24,21 @@ const Header = (): JSX.Element => {
           다양한 주제에 대해 자유롭게 의견을 나눌 수 있도록 하는
           <br /> 커뮤니티 플랫폼입니다.
         </h4>
-        {isLogin ? null : (
+        {isLogin ? (
+          <ButtonLayout
+            text="글 작성 하러가기"
+            width="250px"
+            height="40px"
+            color="var(--pink)" // Pass the CSS variable value as a string
+            background="#ffffff"
+            fontSize="1.125rem"
+            radius="50px"
+            border="none"
+            onClick={() => {
+              router.push("/board/post");
+            }}
+          />
+        ) : (
           <ButtonLayout
             text="로그인 하러가기"
             width="250px"

--- a/every-board/src/components/home/Header.tsx
+++ b/every-board/src/components/home/Header.tsx
@@ -1,11 +1,14 @@
 "use client";
 import styled from "styled-components";
 import ButtonLayout from "../ButtonLayout";
+import Avatar from "../Avatar";
 import Image from "next/image";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 const Header = (): JSX.Element => {
   const router = useRouter();
+  const [isLogin, setLogin] = useState<boolean>(false);
   return (
     <HeaderLayout>
       <TextArea>
@@ -21,19 +24,21 @@ const Header = (): JSX.Element => {
           다양한 주제에 대해 자유롭게 의견을 나눌 수 있도록 하는
           <br /> 커뮤니티 플랫폼입니다.
         </h4>
-        <ButtonLayout
-          text="로그인 하러가기"
-          width="250px"
-          height="40px"
-          color="var(--pink)" // Pass the CSS variable value as a string
-          background="#ffffff"
-          fontSize="1.125rem"
-          radius="50px"
-          border="none"
-          onClick={() => {
-            router.push("/signin");
-          }}
-        />
+        {isLogin ? null : (
+          <ButtonLayout
+            text="로그인 하러가기"
+            width="250px"
+            height="40px"
+            color="var(--pink)" // Pass the CSS variable value as a string
+            background="#ffffff"
+            fontSize="1.125rem"
+            radius="50px"
+            border="none"
+            onClick={() => {
+              router.push("/signin");
+            }}
+          />
+        )}
       </TextArea>
       <ImageArea>
         <Image
@@ -43,6 +48,7 @@ const Header = (): JSX.Element => {
           alt="headerImage"
         />
       </ImageArea>
+      <AvatarArea>{isLogin ? <Avatar /> : null}</AvatarArea>
     </HeaderLayout>
   );
 };
@@ -76,13 +82,12 @@ const TextArea = styled.div`
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding-top: 100px;
+  margin: auto 0;
   gap: 20px;
   h1 {
     font-size: 1.25rem;
   }
   h4 {
-    display: none;
     font-size: 1rem;
     font-weight: 600;
   }
@@ -98,10 +103,8 @@ const TextArea = styled.div`
     }
     h4 {
       min-width: 351px;
-      display: block;
     }
   }
-
   @media (min-width: 1080px) {
     h1 {
       min-width: 472px;
@@ -112,10 +115,15 @@ const TextArea = styled.div`
 
 const ImageArea = styled.div`
   display: none;
-
   @media (min-width: 768px) {
     display: inline-block;
   }
+`;
+
+const AvatarArea = styled.span`
+  position: absolute;
+  top: 20px;
+  right: 20px;
 `;
 
 export default Header;

--- a/every-board/src/components/home/Header.tsx
+++ b/every-board/src/components/home/Header.tsx
@@ -29,28 +29,24 @@ const Header = (): JSX.Element => {
             text="글 작성 하러가기"
             width="250px"
             height="40px"
-            color="var(--pink)" // Pass the CSS variable value as a string
+            color="var(--pink)"
             background="#ffffff"
             fontSize="1.125rem"
             radius="50px"
             border="none"
-            onClick={() => {
-              router.push("/board/post");
-            }}
+            router="/board/post"
           />
         ) : (
           <ButtonLayout
             text="로그인 하러가기"
             width="250px"
             height="40px"
-            color="var(--pink)" // Pass the CSS variable value as a string
+            color="var(--pink)"
             background="#ffffff"
             fontSize="1.125rem"
             radius="50px"
             border="none"
-            onClick={() => {
-              router.push("/signin");
-            }}
+            router="/signin"
           />
         )}
       </TextArea>
@@ -62,7 +58,28 @@ const Header = (): JSX.Element => {
           alt="headerImage"
         />
       </ImageArea>
-      <AvatarArea>{isLogin ? <Avatar /> : null}</AvatarArea>
+
+      <AvatarArea>
+        {isLogin ? (
+          <Avatar />
+        ) : (
+          // 로그인 기능 구현되면 지울 부분
+          <ButtonLayout
+            text="임시 : 로그인 상태로바꾸기"
+            width="fit-content"
+            height="40px"
+            color="var(--pink)" // Pass the CSS variable value as a string
+            background="#ffffff"
+            fontSize="0.9rem"
+            radius="50px"
+            padding="10px"
+            border="none"
+            onClick={() => {
+              setLogin(true);
+            }}
+          />
+        )}
+      </AvatarArea>
     </HeaderLayout>
   );
 };

--- a/every-board/src/components/home/PhotoLine.tsx
+++ b/every-board/src/components/home/PhotoLine.tsx
@@ -14,6 +14,7 @@ const PhotoLine = () => {
           background="var(--primary)"
           color=" #ffffff"
           text="더보기"
+          border="none"
         ></ButtonLayout>
       </TitleWrap>
       <PhotoWrap>

--- a/every-board/src/components/home/PhotoLine.tsx
+++ b/every-board/src/components/home/PhotoLine.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
 import ButtonLayout from "@/components/ButtonLayout";
+import { useRouter } from "next/navigation";
 
 const PhotoLine = () => {
+  const router = useRouter();
   const photo = [1, 2, 3, 4];
   return (
     <Section>
@@ -15,6 +17,9 @@ const PhotoLine = () => {
           color=" #ffffff"
           text="더보기"
           border="none"
+          onClick={() => {
+            router.push("/gallery");
+          }}
         ></ButtonLayout>
       </TitleWrap>
       <PhotoWrap>


### PR DESCRIPTION
1. Avatar 컴포넌트 수정
    - 닉네임 최대 10글자 까지만보이게 수정
    - 클릭시 mypofile 라우팅 되도록 설정
2. 홈화면에서 HIT 갤러리의 더보기 클릭 시 이미지만 따로 보여지는 페이지가 필요할 것 같아 gallery라는 페이지 생성
3. 로그인 상태에 따라 홈화면의 버튼이 다르게 보이게 설정 
    - 로그인이 아닐 시 `로그인 하러가기` 로그인일 시 `글 작성하러 가기`
4. comment 컴포넌트가 어색하게 보이는 것 수정
5. Header 컴포넌트를 처음에 했던 대로 layout에 상속
    - Header의 title은 상단 Url에서 꺼내쓰는 방식
6. 5번 사항으로 인해 기존 페이지에 Header 컴포넌트 삭제
